### PR TITLE
[feat] 관리자페이지 즉시픽업 기능

### DIFF
--- a/src/main/java/org/eDrink24/config/AdminMapper.java
+++ b/src/main/java/org/eDrink24/config/AdminMapper.java
@@ -1,0 +1,29 @@
+package org.eDrink24.config;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.eDrink24.dto.admin.AdminDTO;
+
+import java.util.HashMap;
+import java.util.List;
+
+@Mapper
+public interface AdminMapper {
+
+    // 픽업완료버튼 클릭 시 IsCompleted true로 변경,
+    public int changeIsCompleted(@Param("ordersId") Integer ordersId);
+
+    // changeStatus PICKUPED, changeDate 버튼 클릭 한 시간으로 변경
+    public int ChangeStatusAndDate(@Param("ordersId") Integer ordersId);
+
+    // 픽업완료버튼 클릭 시 inventory테이블 수량 변경
+    public int changeInventoryQuantity(@Param("ordersId") Integer ordersId);
+
+    // 픽업완료 내역페이지에서 픽업주문처리가 완료된 것만 보여줌. (isCompleted가 true)
+    public List<AdminDTO> showPickupCompletedPage();
+
+    // 즉시픽업페이지에서 즉시픽업이 아직 이루어지지 않은 것만 보여줌. (isCompleted가 false)
+    public List<AdminDTO> showPickupPage();
+
+
+}

--- a/src/main/java/org/eDrink24/controller/admin/AdminController.java
+++ b/src/main/java/org/eDrink24/controller/admin/AdminController.java
@@ -1,0 +1,34 @@
+package org.eDrink24.controller.admin;
+
+import org.eDrink24.dto.admin.AdminDTO;
+import org.eDrink24.service.admin.AdminService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+public class AdminController {
+
+    AdminService adminService;
+
+    public AdminController(AdminService adminService) {
+        this.adminService = adminService;
+    }
+    
+    @PutMapping(value = {"/updateStateAfterCompletedPickup/{ordersId}"})
+    public ResponseEntity<Void> updateStateAfterCompletedPickup(@PathVariable Integer ordersId) {
+        adminService.updateStateAfterCompletedPickup(ordersId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping(value = {"/showPickupCompletedPage"})
+    public List<AdminDTO> showPickupCompletedPage() {
+        return adminService.showPickupCompletedPage();
+    }
+
+    @GetMapping(value = {"/showPickupPage"})
+    public List<AdminDTO> showPickupPage() {
+        return adminService.showPickupPage();
+    }
+}

--- a/src/main/java/org/eDrink24/dto/admin/AdminDTO.java
+++ b/src/main/java/org/eDrink24/dto/admin/AdminDTO.java
@@ -1,0 +1,29 @@
+package org.eDrink24.dto.admin;
+
+import lombok.*;
+import org.apache.ibatis.type.Alias;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+
+@Alias("AdminDTO")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@Setter
+@ToString
+public class AdminDTO {
+    private Integer ordersId;
+    private Integer storeId;
+    private Integer userId;
+    private Integer productId;
+    private LocalDateTime orderDate;
+    private Boolean isCompleted;
+    private String changeStatus;
+    private LocalDateTime changeDate;
+    private Integer orderQuantity;
+}

--- a/src/main/java/org/eDrink24/service/admin/AdminService.java
+++ b/src/main/java/org/eDrink24/service/admin/AdminService.java
@@ -1,0 +1,12 @@
+package org.eDrink24.service.admin;
+
+import org.eDrink24.dto.admin.AdminDTO;
+
+import java.util.HashMap;
+import java.util.List;
+
+public interface AdminService {
+    public void updateStateAfterCompletedPickup(Integer ordersId);
+    public List<AdminDTO> showPickupCompletedPage();
+    public List<AdminDTO> showPickupPage();
+}

--- a/src/main/java/org/eDrink24/service/admin/AdminServiceImpl.java
+++ b/src/main/java/org/eDrink24/service/admin/AdminServiceImpl.java
@@ -1,0 +1,38 @@
+package org.eDrink24.service.admin;
+
+import org.eDrink24.config.AdminMapper;
+import org.eDrink24.dto.admin.AdminDTO;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Transactional
+public class AdminServiceImpl implements AdminService{
+
+    AdminMapper adminMapper;
+
+    public AdminServiceImpl(AdminMapper adminMapper) {
+        this.adminMapper = adminMapper;
+    }
+
+    @Override
+    public void updateStateAfterCompletedPickup(Integer ordersId) {
+        adminMapper.ChangeStatusAndDate(ordersId);
+        adminMapper.changeIsCompleted(ordersId);
+        adminMapper.changeInventoryQuantity(ordersId);
+    }
+
+    @Override
+    public List<AdminDTO> showPickupCompletedPage() {
+        return adminMapper.showPickupCompletedPage();
+    }
+
+    @Override
+    public List<AdminDTO> showPickupPage() {
+        return adminMapper.showPickupPage();
+    }
+}

--- a/src/main/resources/config/AdminMapper.xml
+++ b/src/main/resources/config/AdminMapper.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.eDrink24.config.AdminMapper">
+
+    <update id="changeIsCompleted" parameterType="Integer">
+        update orders
+        set isCompleted=true
+        where ordersId=#{ordersId}
+    </update>
+
+    <update id="ChangeStatusAndDate" parameterType="Integer">
+        update orderhistory
+        set changeStatus="PICKUPED", changeDate=NOW()
+        where ordersId=#{ordersId}
+    </update>
+
+    <!-- 현재 order페이지에서 선택하는 매장의 storeId와 DB에 들어가있는 storeId가 달라서
+     일단은 productId만 같으면 수량이 줄어들도록 구현해놨음.
+     나중에 storeId가 일치하게 되면 밑에 주석으로 나둔 부분 풀어서 실행하면
+     storeId와  productId가 일치하는 것만 수량이 업데이트되게 하면됨.-->
+    <update id="changeInventoryQuantity" parameterType="map">
+        UPDATE inventory
+        SET quantity = quantity - (
+        SELECT orderQuantity
+        FROM orders
+        WHERE ordersId = #{ordersId}
+        )
+        WHERE productId = (
+        SELECT productId
+        FROM orders
+        WHERE ordersId = #{ordersId}
+        )
+<!--        AND storeId = (-->
+<!--        SELECT storeId-->
+<!--        FROM orders-->
+<!--        WHERE ordersId = #{ordersId}-->
+<!--        )-->
+    </update>
+
+
+    <select id="showPickupCompletedPage" resultType="AdminDTO">
+        select o.ordersId, o.storeId, o.userId, o.productId, o.orderDate, o.isCompleted, oh.changeStatus,oh.changeDate, o.orderQuantity
+        from orders o join orderhistory oh on o.ordersId = oh.ordersId
+        where o.isCompleted=true
+    </select>
+
+    <select id="showPickupPage" resultType="AdminDTO">
+        select o.ordersId, o.storeId, o.userId, o.productId, o.orderDate, o.isCompleted, oh.changeStatus,oh.changeDate, o.orderQuantity
+        from orders o join orderhistory oh on o.ordersId = oh.ordersId
+        where o.isCompleted=false
+    </select>
+
+</mapper>
+


### PR DESCRIPTION
- 주문완료된 목록들을 즉시픽업 목록페이지에 보여주고 픽업완료 버튼을 누르면 즉시픽업 완료내역페이지에서 픽업완료된 것들의 내역을 보여줌.

- 픽업완료된 목록들은 즉시픽업페이지에서 삭제되고 즉시픽업 완료내역페이지에서 보여줌.

- 픽업완료 버튼 클릭 시 order테이블의 isCompleted는 true로 변경되고 orderhistory테이블의 changeStatus는 "PICKUPED", changeDate는 현재 시간으로 변경, 마지막으로 inventory의 quantity도 줄어듬.