### PR TITLE
[refactor] 주문-결제 동시성 및 플로우 리팩터링

### DIFF
--- a/src/main/java/org/eDrink24/config/InventoryMapper.java
+++ b/src/main/java/org/eDrink24/config/InventoryMapper.java
@@ -1,0 +1,9 @@
+package org.eDrink24.config;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface InventoryMapper {
+
+
+}

--- a/src/main/java/org/eDrink24/config/InventoryMapper.java
+++ b/src/main/java/org/eDrink24/config/InventoryMapper.java
@@ -1,9 +1,12 @@
 package org.eDrink24.config;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.eDrink24.dto.Inventory.InventoryDTO;
+
+import java.util.Map;
 
 @Mapper
 public interface InventoryMapper {
-
-
+    public InventoryDTO findInventoryForUpdate(Map<String, Integer> map);
+    public int updateInventory(Map<String, Integer> map);
 }

--- a/src/main/java/org/eDrink24/controller/customer/CustomerController.java
+++ b/src/main/java/org/eDrink24/controller/customer/CustomerController.java
@@ -31,7 +31,6 @@ public class CustomerController {
         customer.setPw(ecrptPW);
 
         CustomerDTO saveCustomer = customerService.saveCustomer(customer);
-        System.out.println("KKKKKKKKKKKKKKKKK" + saveCustomer);
         customerService.addSignupCoupon(customer.getUserId());
 
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()

--- a/src/main/java/org/eDrink24/controller/order/OrderController.java
+++ b/src/main/java/org/eDrink24/controller/order/OrderController.java
@@ -25,7 +25,6 @@ public class OrderController {
 
         try {
             orderService.buyProductAndSaveHistory(orderTransactionDTO, userId, couponId);
-            //orderService.deleteBasketAndItem(orderTransactionDTO);
             return ResponseEntity.ok("Purchase successful");
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/org/eDrink24/controller/order/OrderController.java
+++ b/src/main/java/org/eDrink24/controller/order/OrderController.java
@@ -22,14 +22,8 @@ public class OrderController {
     @PostMapping("/showAllBasket/userId/{userId}/buyProductAndSaveHistory")
     public ResponseEntity<String> buyProductAndSaveHistory(@RequestBody List<OrderTransactionDTO> orderTransactionDTO,
                                                            @PathVariable Integer userId, Integer couponId) {
-
-        try {
-            orderService.buyProductAndSaveHistory(orderTransactionDTO, userId, couponId);
-            return ResponseEntity.ok("Purchase successful");
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body("Error processing purchase: " + e.getMessage());
-        }
+        orderService.buyProductAndSaveHistory(orderTransactionDTO, userId, couponId);
+        return ResponseEntity.ok("Purchase successful");
     }
 
     @DeleteMapping("/showAllBasket/userId/{userId}/deleteBasketAndItem")

--- a/src/main/java/org/eDrink24/excpetion/GlobalExceptionHandler.java
+++ b/src/main/java/org/eDrink24/excpetion/GlobalExceptionHandler.java
@@ -1,17 +1,27 @@
 package org.eDrink24.excpetion;
 
+import lombok.extern.slf4j.Slf4j;
 import org.eDrink24.excpetion.NotEnoughStock.NotEnoughStockException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+@Slf4j
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
     // 주문 시, 오늘픽업 재고부족으로 인한 예외
     @ExceptionHandler(NotEnoughStockException.class)
     public ResponseEntity<String> notEnoughStockException(NotEnoughStockException e) {
+        log.error("재고부족 예외: {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    }
+
+    // 모든 예외를 처리하는 핸들러 추가
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleAllExceptions(Exception e) {
+        log.error("서버내부 예외: {}", e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("서버오류 발생: "+e.getMessage());
     }
 }

--- a/src/main/java/org/eDrink24/excpetion/GlobalExceptionHandler.java
+++ b/src/main/java/org/eDrink24/excpetion/GlobalExceptionHandler.java
@@ -1,0 +1,17 @@
+package org.eDrink24.excpetion;
+
+import org.eDrink24.excpetion.NotEnoughStock.NotEnoughStockException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 주문 시, 오늘픽업 재고부족으로 인한 예외
+    @ExceptionHandler(NotEnoughStockException.class)
+    public ResponseEntity<String> notEnoughStockException(NotEnoughStockException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    }
+}

--- a/src/main/java/org/eDrink24/excpetion/NotEnoughStock/NotEnoughStockException.java
+++ b/src/main/java/org/eDrink24/excpetion/NotEnoughStock/NotEnoughStockException.java
@@ -1,0 +1,7 @@
+package org.eDrink24.excpetion.NotEnoughStock;
+
+public class NotEnoughStockException extends RuntimeException {
+    public NotEnoughStockException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/eDrink24/service/admin/AdminServiceImpl.java
+++ b/src/main/java/org/eDrink24/service/admin/AdminServiceImpl.java
@@ -28,7 +28,9 @@ public class AdminServiceImpl implements AdminService{
     public void updateStateAfterCompletedPickup(Integer ordersId) {
         adminMapper.ChangeStatusAndDate(ordersId);
         adminMapper.changeIsCompleted(ordersId);
-        adminMapper.changeInventoryQuantity(ordersId);
+
+        // 픽업완료처리 했을때 수량 바뀜 => 주문 시에 처리해얄듯
+        // adminMapper.changeInventoryQuantity(ordersId);
     }
 
     @Override

--- a/src/main/java/org/eDrink24/service/basket/BasketServiceImpl.java
+++ b/src/main/java/org/eDrink24/service/basket/BasketServiceImpl.java
@@ -25,8 +25,6 @@ public class BasketServiceImpl implements BasketService {
     @Transactional
     public void saveProductToBasket(BasketDTO basketDTO) {
 
-        System.out.println(">>>>>>>>>>>>>>>>>>>>." + basketDTO);
-
         //부모 테이블에 저장
         basketMapper.saveBasket(basketDTO);
         // 부모 테이블에 저장 후 자동 생성된 basketId 설정

--- a/src/main/java/org/eDrink24/service/order/OrderServiceImpl.java
+++ b/src/main/java/org/eDrink24/service/order/OrderServiceImpl.java
@@ -56,6 +56,16 @@ public class OrderServiceImpl implements OrderService {
             // 주문 저장
             orderMapper.buyProduct(orderTransactionDTO);
 
+            for (OrderTransactionDTO orderTransaction : orderTransactionDTO) {
+                int storeId = orderTransaction.getStoreId();
+                int productId = orderTransaction.getProductId();
+                String pickupType = orderTransaction.getPickupType();
+                int quantity = orderTransaction.getOrderQuantity();
+                if (pickupType.equals("TODAY")) {
+
+                }
+            }
+
             // 주문 내역 저장
             orderMapper.saveBuyHistory(orderTransactionDTO);
 
@@ -74,8 +84,7 @@ public class OrderServiceImpl implements OrderService {
             map1.put("pointAmount", orderTransactionDTO.get(0).getPointAmount());
             orderMapper.reduceTotalPoint(map1);
 
-            couponId = orderTransactionDTO.get(0).getCouponId();
-            System.out.println("FFFFFFFFFFFFFFFFFF"+couponId);
+            couponId = orderTransactionDTO.get(0).getCouponId();;
             // 쿠폰이 사용된 경우에만 업데이트
             if (couponId != null) {
                 HashMap<String, Integer> map2 = new HashMap<>();

--- a/src/main/java/org/eDrink24/service/order/OrderServiceImpl.java
+++ b/src/main/java/org/eDrink24/service/order/OrderServiceImpl.java
@@ -7,6 +7,7 @@ import org.eDrink24.dto.Inventory.InventoryDTO;
 import org.eDrink24.dto.basket.BasketDTO;
 import org.eDrink24.dto.basket.BasketItemDTO;
 import org.eDrink24.dto.order.OrderTransactionDTO;
+import org.eDrink24.excpetion.NotEnoughStock.NotEnoughStockException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -75,7 +76,7 @@ public class OrderServiceImpl implements OrderService {
                     System.out.println(inventory);
                     if(inventory==null || inventory.getQuantity() < quantity) {
                         System.out.println("!error!");
-                        throw new IllegalArgumentException("재고 부족으로 주문불가"); // 나중에 전역예외처리 필요. 발생하면 아래 코드 실행X
+                        throw new NotEnoughStockException("매장재고부족"); // 나중에 전역예외처리 필요. 발생하면 아래 코드 실행X
                     }
                     inventoryMapper.updateInventory(map);
                 }

--- a/src/main/java/org/eDrink24/service/order/OrderServiceImpl.java
+++ b/src/main/java/org/eDrink24/service/order/OrderServiceImpl.java
@@ -61,7 +61,7 @@ public class OrderServiceImpl implements OrderService {
             for (OrderTransactionDTO orderTransaction : orderTransactionDTO) {
                 // 재고감소는 오늘픽업일때만, 예약픽업은 점주의 발주처리가 완료되어야 재고가 생김
                 String pickupType = orderTransaction.getPickupType();
-                if (!pickupType.equals("TODAY")) {
+                if (pickupType.equals("TODAY")) {
                     int storeId = orderTransaction.getStoreId();
                     int productId = orderTransaction.getProductId();
                     int quantity = orderTransaction.getOrderQuantity();
@@ -72,7 +72,9 @@ public class OrderServiceImpl implements OrderService {
                     map.put("quantity", quantity);
 
                     InventoryDTO inventory = inventoryMapper.findInventoryForUpdate(map);
+                    System.out.println(inventory);
                     if(inventory==null || inventory.getQuantity() < quantity) {
+                        System.out.println("!error!");
                         throw new IllegalArgumentException("재고 부족으로 주문불가"); // 나중에 전역예외처리 필요. 발생하면 아래 코드 실행X
                     }
                     inventoryMapper.updateInventory(map);

--- a/src/main/java/org/eDrink24/service/order/OrderServiceImpl.java
+++ b/src/main/java/org/eDrink24/service/order/OrderServiceImpl.java
@@ -57,19 +57,20 @@ public class OrderServiceImpl implements OrderService {
     @Transactional
     public void buyProductAndSaveHistory(List<OrderTransactionDTO> orderTransactionDTO, Integer userId, Integer couponId) {
         if (orderTransactionDTO != null && !orderTransactionDTO.isEmpty()) {
+
             for (OrderTransactionDTO orderTransaction : orderTransactionDTO) {
-                int storeId = orderTransaction.getStoreId();
-                int productId = orderTransaction.getProductId();
-                int quantity = orderTransaction.getOrderQuantity();
-                String pickupType = orderTransaction.getPickupType();
-
-                Map<String, Integer> map = new HashMap<>();
-                map.put("storeId", storeId);
-                map.put("productId", productId);
-                map.put("quantity", quantity);
-
                 // 재고감소는 오늘픽업일때만, 예약픽업은 점주의 발주처리가 완료되어야 재고가 생김
+                String pickupType = orderTransaction.getPickupType();
                 if (!pickupType.equals("TODAY")) {
+                    int storeId = orderTransaction.getStoreId();
+                    int productId = orderTransaction.getProductId();
+                    int quantity = orderTransaction.getOrderQuantity();
+
+                    Map<String, Integer> map = new HashMap<>();
+                    map.put("storeId", storeId);
+                    map.put("productId", productId);
+                    map.put("quantity", quantity);
+
                     InventoryDTO inventory = inventoryMapper.findInventoryForUpdate(map);
                     if(inventory==null || inventory.getQuantity() < quantity) {
                         throw new IllegalArgumentException("재고 부족으로 주문불가"); // 나중에 전역예외처리 필요. 발생하면 아래 코드 실행X

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,7 +7,7 @@ server.servlet.context-path=/eDrink24
 spring.profiles.include=secret
 
 # JPA
-spring.jpa.show-sql=true
+#spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 

--- a/src/main/resources/config/InventoryMapper.xml
+++ b/src/main/resources/config/InventoryMapper.xml
@@ -6,7 +6,7 @@
 <mapper namespace="org.eDrink24.config.InventoryMapper">
     <select id="findInventoryForUpdate" parameterType="map" resultType="InventoryDTO">
         SELECT * FROM inventory
-        WHERE store_id = #{storeId} AND product_id = #{productId}
+        WHERE storeId = #{storeId} AND productId = #{productId}
         FOR UPDATE <!--해당 레코드를 잠금 처리. 트랜잭션이 끝나면 풀림-->
     </select>
 

--- a/src/main/resources/config/InventoryMapper.xml
+++ b/src/main/resources/config/InventoryMapper.xml
@@ -4,10 +4,15 @@
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.eDrink24.config.InventoryMapper">
-    <update id="updateInventoryByOrder" parameterType="map">
+    <select id="findInventoryForUpdate" parameterType="map" resultType="InventoryDTO">
+        SELECT * FROM inventory
+        WHERE store_id = #{storeId} AND product_id = #{productId}
+        FOR UPDATE <!--해당 레코드를 잠금 처리. 트랜잭션이 끝나면 풀림-->
+    </select>
+
+    <update id="updateInventory" parameterType="map">
         UPDATE inventory
         SET quantity = quantity - #{quantity}
-        WHERE productId = #{productId}
-        AND storeId = #{storeId{
+        WHERE productId = #{productId} AND storeId = #{storeId}
     </update>
 </mapper>

--- a/src/main/resources/config/InventoryMapper.xml
+++ b/src/main/resources/config/InventoryMapper.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.eDrink24.config.InventoryMapper">
+    <update id="updateInventoryByOrder" parameterType="map">
+        UPDATE inventory
+        SET quantity = quantity - #{quantity}
+        WHERE productId = #{productId}
+        AND storeId = #{storeId{
+    </update>
+</mapper>

--- a/src/test/java/org/eDrink24/OrderTests.java
+++ b/src/test/java/org/eDrink24/OrderTests.java
@@ -1,7 +1,10 @@
 package org.eDrink24;
 
+import org.eDrink24.config.InventoryMapper;
 import org.eDrink24.domain.customer.Customer;
+import org.eDrink24.dto.Inventory.InventoryDTO;
 import org.eDrink24.dto.customer.CustomerDTO;
+import org.eDrink24.dto.order.OrderTransactionDTO;
 import org.eDrink24.service.customer.AuthenticationService;
 import org.eDrink24.service.customer.AuthenticationServiceImpl;
 import org.eDrink24.service.customer.CustomerService;
@@ -11,6 +14,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import javax.transaction.Transactional;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 
 @SpringBootTest
 @Transactional
@@ -20,12 +28,55 @@ public class OrderTests {
     private AuthenticationService authenticationService;
     @Autowired
     private OrderService orderService;
+    @Autowired
+    private InventoryMapper inventoryMapper;
 
     @Test
     public void ConcurrencyTest() throws InterruptedException {
-        // 3명 로그인
-        CustomerDTO customer1 = authenticationService.authenticate("hmdkcm1", "$2a$10$Ezosoh6hRbwhxarWiCQfgOWCFieNzWvIpKnc1dc350arucz2rWi8.");
-        CustomerDTO customer2 = authenticationService.authenticate("hmdkcm2", "$2a$10$o5VcW4gA8yEHjvHSZVaRzehglKSay7Y8zD3utsxhT/06KSwC7Ql52");
-        CustomerDTO customer3 = authenticationService.authenticate("hmdkcm3", "$2a$10$l0/eoQxrVX7otDNWd3J7R./FwOj.xTzaMIX6ysVGWCDrQEWLuNl.e");
+        int storeId = 1331;
+        int productId = 81;
+        int orderQuantity = 3;
+
+        Map<String, Integer> map = new HashMap<>();
+        map.put("storeId", storeId);
+        map.put("productId", productId);
+        map.put("quantity", orderQuantity);
+
+        // 동시성 테스트를 위한 스레드 동기화
+        CountDownLatch latch = new CountDownLatch(3);
+
+        Runnable task = () -> {
+            try {
+                InventoryDTO inventory = inventoryMapper.findInventoryForUpdate(map);
+                if (inventory == null || inventory.getQuantity() < orderQuantity) {
+                    System.out.println("재고 부족으로 주문 불가");
+                } else {
+                    inventoryMapper.updateInventory(map);
+                    System.out.println("재고 감소 성공");
+                }
+            } catch (Exception e) {
+                System.out.println("예외 발생: " + e.getMessage());
+            } finally {
+                latch.countDown();
+            }
+        };
+
+        // 각 스레드 생성
+        Thread thread1 = new Thread(task);
+        Thread thread2 = new Thread(task);
+        Thread thread3 = new Thread(task);
+
+        thread1.start();
+        thread2.start();
+        thread3.start();
+
+        latch.await();
+
+        // 결과 확인
+        System.out.println("동시성 테스트 완료");
+
+        // 최종 재고 수량 확인
+        InventoryDTO finalInventory = inventoryMapper.findInventoryForUpdate(map);
+        System.out.println("최종 재고 수량: " + (finalInventory != null ? finalInventory.getQuantity() : "재고 없음"));
     }
 }

--- a/src/test/java/org/eDrink24/OrderTests.java
+++ b/src/test/java/org/eDrink24/OrderTests.java
@@ -1,0 +1,31 @@
+package org.eDrink24;
+
+import org.eDrink24.domain.customer.Customer;
+import org.eDrink24.dto.customer.CustomerDTO;
+import org.eDrink24.service.customer.AuthenticationService;
+import org.eDrink24.service.customer.AuthenticationServiceImpl;
+import org.eDrink24.service.customer.CustomerService;
+import org.eDrink24.service.order.OrderService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.transaction.Transactional;
+
+@SpringBootTest
+@Transactional
+public class OrderTests {
+
+    @Autowired
+    private AuthenticationService authenticationService;
+    @Autowired
+    private OrderService orderService;
+
+    @Test
+    public void ConcurrencyTest() throws InterruptedException {
+        // 3명 로그인
+        CustomerDTO customer1 = authenticationService.authenticate("hmdkcm1", "$2a$10$Ezosoh6hRbwhxarWiCQfgOWCFieNzWvIpKnc1dc350arucz2rWi8.");
+        CustomerDTO customer2 = authenticationService.authenticate("hmdkcm2", "$2a$10$o5VcW4gA8yEHjvHSZVaRzehglKSay7Y8zD3utsxhT/06KSwC7Ql52");
+        CustomerDTO customer3 = authenticationService.authenticate("hmdkcm3", "$2a$10$l0/eoQxrVX7otDNWd3J7R./FwOj.xTzaMIX6ysVGWCDrQEWLuNl.e");
+    }
+}


### PR DESCRIPTION
- InventoryMapper 생성 후, 재고확인 + 재고차감 메서드 생성
- OrderController 로직 수정을 통해 기존 재고차감을 주문과 결제 사이드로 가져옴
- LocalException-GlobalException 플로우를 통해 예외처리
- DB에 CHECK제약조건을 걸어 Inventory 테이블의 일관성 확보 + Mapper에 FOR UPDATE를 달아 비관적 락 적용 (테스트 과정에서 파악할 수 없었지만 동시성 문제를 고려함)

### 정리과정
[[Trouble Shooting/Back-end] Inventory-Order 동시성문제](https://ysstudy.notion.site/Trouble-Shooting-Back-end-Inventory-Order-11102f7b1371802cb642f3eb78afdb4c?pvs=4)
